### PR TITLE
add caching io attachment/detachment replies

### DIFF
--- a/src/app/lego-hub/features/attached-io-replies-cache-factory.service.ts
+++ b/src/app/lego-hub/features/attached-io-replies-cache-factory.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { AttachedIoRepliesCache } from './attached-io-replies-cache';
+import { Observable } from 'rxjs';
+import { AttachedIOInboundMessage } from '../messages';
+
+@Injectable()
+export class AttachedIoRepliesCacheFactoryService {
+    public create(
+        messages$: Observable<AttachedIOInboundMessage>,
+        onDisconnected$: Observable<void>,
+    ): AttachedIoRepliesCache {
+        return new AttachedIoRepliesCache(messages$, onDisconnected$);
+    }
+}

--- a/src/app/lego-hub/features/attached-io-replies-cache.ts
+++ b/src/app/lego-hub/features/attached-io-replies-cache.ts
@@ -1,0 +1,42 @@
+import { AttachedIOInboundMessage } from '../messages';
+import { Observable, take, takeUntil, TeardownLogic } from 'rxjs';
+import { AttachIoEvent } from '../constants';
+
+export class AttachedIoRepliesCache {
+    public readonly replies$: Observable<AttachedIOInboundMessage>;
+
+    private cacheMap = new Map<number, AttachedIOInboundMessage>();
+
+    constructor(
+        private readonly messages$: Observable<AttachedIOInboundMessage>,
+        private readonly onDisconnected$: Observable<void>,
+    ) {
+        this.replies$ = new Observable((observer) => {
+            if (this.cacheMap.size) {
+                [ ...this.cacheMap.values() ].forEach((message) => {
+                    observer.next(message);
+                });
+            }
+            const sub = this.messages$.subscribe((reply) => {
+                observer.next(reply);
+            });
+            return (): TeardownLogic => sub.unsubscribe();
+        });
+
+        this.messages$.pipe(
+            takeUntil(this.onDisconnected$)
+        ).subscribe((reply) => this.addReply(reply));
+
+        this.onDisconnected$.pipe(
+            take(1)
+        ).subscribe(() => this.cacheMap.clear());
+    }
+
+    private addReply(reply: AttachedIOInboundMessage): void {
+        if (reply.event === AttachIoEvent.Detached) {
+            this.cacheMap.delete(reply.portId);
+        } else {
+            this.cacheMap.set(reply.portId, reply);
+        }
+    }
+}

--- a/src/app/lego-hub/features/index.ts
+++ b/src/app/lego-hub/features/index.ts
@@ -4,3 +4,4 @@ export * from './hub-properties-feature';
 export * from './hub-properties-feature-factory.service';
 export * from './motor-feature';
 export * from './motor-feature-factory.service';
+export * from './attached-io-replies-cache-factory.service';

--- a/src/app/lego-hub/features/io-feature-factory.service.ts
+++ b/src/app/lego-hub/features/io-feature-factory.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../messages';
 import { Observable } from 'rxjs';
 import { MessageType } from '../constants';
+import { AttachedIoRepliesCacheFactoryService } from './attached-io-replies-cache-factory.service';
 
 @Injectable()
 export class IoFeatureFactoryService {
@@ -26,6 +27,7 @@ export class IoFeatureFactoryService {
         private readonly portModeInformationOutboundMessageFactoryService: PortModeInformationRequestOutboundMessageFactoryService,
         private readonly portInputFormatSetupSingleOutboundMessageFactoryService: PortInputFormatSetupSingleOutboundMessageFactoryService,
         private readonly portModeInformationReplyParserService: PortModeInformationReplyParserService,
+        private readonly attachedIoRepliesCacheFactoryService: AttachedIoRepliesCacheFactoryService,
     ) {
     }
 
@@ -67,6 +69,8 @@ export class IoFeatureFactoryService {
             this.portModeInformationOutboundMessageFactoryService,
             this.portInputFormatSetupSingleOutboundMessageFactoryService,
             messenger,
+            this.attachedIoRepliesCacheFactoryService,
+            onHubDisconnected,
         );
     }
 }

--- a/src/app/lego-hub/provide-lego-hub-environment.ts
+++ b/src/app/lego-hub/provide-lego-hub-environment.ts
@@ -18,9 +18,9 @@ import {
     PortOperationsOutboundMessageFactoryService,
     PortValueReplyParserService
 } from './messages';
-import { HubPropertiesFeatureFactoryService, IoFeatureFactoryService, MotorFeatureFactoryService } from './features';
+import { AttachedIoRepliesCacheFactoryService, HubPropertiesFeatureFactoryService, IoFeatureFactoryService, MotorFeatureFactoryService } from './features';
 import { ILegoHubConfig, LEGO_HUB_CONFIG, mergeConfig } from './i-lego-hub-config';
-import { HubLoggerFactoryService } from './logging/hub-logger-factory.service';
+import { HubLoggerFactoryService } from './logging';
 
 export function provideLegoHubEnvironment(config: Partial<ILegoHubConfig>): EnvironmentProviders {
     return makeEnvironmentProviders([
@@ -46,6 +46,7 @@ export function provideLegoHubEnvironment(config: Partial<ILegoHubConfig>): Envi
             PortOperationsOutboundMessageFactoryService,
             PortInputFormatSetupSingleOutboundMessageFactoryService,
             HubLoggerFactoryService,
+            AttachedIoRepliesCacheFactoryService,
             { provide: LEGO_HUB_CONFIG, useValue: mergeConfig(config) }
         ]
     ]);


### PR DESCRIPTION
(had to be done because hub sends attached io messages immediately on connect and there are no way to know what was connected if you are late to the party)